### PR TITLE
Add golangci-lint and fix lint errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Setup Go
+      - name: Set up aqua
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.56.1
+
+      - name: Run golangci-lint
+        run: golangci-lint run
+
+      - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version-file: go.mod

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  default: standard
+
+formatters:
+  enable:
+    - goimports

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.450.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: golangci/golangci-lint@v2.7.2

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -10,11 +10,7 @@ import (
 )
 
 func TestGenerateCommand_Success(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "mfa-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// JBSWY3DPEHPK3PXP is a valid base32 encoded secret
 	configContent := `service:
@@ -26,9 +22,7 @@ func TestGenerateCommand_Success(t *testing.T) {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 
-	originalEnv := os.Getenv("MFA_CONFIG")
-	os.Setenv("MFA_CONFIG", configPath)
-	defer os.Setenv("MFA_CONFIG", originalEnv)
+	t.Setenv("MFA_CONFIG", configPath)
 
 	cmd := NewCommand()
 	buf := new(bytes.Buffer)
@@ -36,7 +30,7 @@ func TestGenerateCommand_Success(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"gen", "test-service"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -51,11 +45,7 @@ func TestGenerateCommand_Success(t *testing.T) {
 }
 
 func TestGenerateCommand_ServiceNotFound(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "mfa-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configContent := `service:
   - name: existing-service
@@ -66,9 +56,7 @@ func TestGenerateCommand_ServiceNotFound(t *testing.T) {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 
-	originalEnv := os.Getenv("MFA_CONFIG")
-	os.Setenv("MFA_CONFIG", configPath)
-	defer os.Setenv("MFA_CONFIG", originalEnv)
+	t.Setenv("MFA_CONFIG", configPath)
 
 	cmd := NewCommand()
 	buf := new(bytes.Buffer)
@@ -76,7 +64,7 @@ func TestGenerateCommand_ServiceNotFound(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"gen", "nonexistent-service"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error for nonexistent service")
 	}
@@ -87,11 +75,7 @@ func TestGenerateCommand_ServiceNotFound(t *testing.T) {
 }
 
 func TestGenerateCommand_InvalidSecret(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "mfa-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configContent := `service:
   - name: invalid-service
@@ -102,9 +86,7 @@ func TestGenerateCommand_InvalidSecret(t *testing.T) {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 
-	originalEnv := os.Getenv("MFA_CONFIG")
-	os.Setenv("MFA_CONFIG", configPath)
-	defer os.Setenv("MFA_CONFIG", originalEnv)
+	t.Setenv("MFA_CONFIG", configPath)
 
 	cmd := NewCommand()
 	buf := new(bytes.Buffer)
@@ -112,7 +94,7 @@ func TestGenerateCommand_InvalidSecret(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"gen", "invalid-service"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error for invalid secret")
 	}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -9,11 +9,7 @@ import (
 )
 
 func TestListCommand_PrintsServices(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "mfa-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configContent := `service:
   - name: amazon
@@ -28,16 +24,14 @@ func TestListCommand_PrintsServices(t *testing.T) {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 
-	originalEnv := os.Getenv("MFA_CONFIG")
-	os.Setenv("MFA_CONFIG", configPath)
-	defer os.Setenv("MFA_CONFIG", originalEnv)
+	t.Setenv("MFA_CONFIG", configPath)
 
 	cmd := NewCommand()
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"list"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,10 +38,10 @@ func NewCommand() *cobra.Command {
 
 func Execute() {
 	cmd := NewCommand()
-	cmd.SetOutput(os.Stdout)
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
 	if err := cmd.Execute(); err != nil {
-		cmd.SetOutput(os.Stderr)
-		cmd.Println("Error:", err)
+		_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,11 +7,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "mfa-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	configContent := `service:
   - name: test-service
@@ -24,9 +20,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Fatalf("failed to write config file: %v", err)
 	}
 
-	originalEnv := os.Getenv("MFA_CONFIG")
-	os.Setenv("MFA_CONFIG", configPath)
-	defer os.Setenv("MFA_CONFIG", originalEnv)
+	t.Setenv("MFA_CONFIG", configPath)
 
 	config, _, err := LoadConfig()
 	if err != nil {
@@ -51,9 +45,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestLoadConfig_FileNotFound(t *testing.T) {
-	originalEnv := os.Getenv("MFA_CONFIG")
-	os.Setenv("MFA_CONFIG", "/nonexistent/path/secrets.yml")
-	defer os.Setenv("MFA_CONFIG", originalEnv)
+	t.Setenv("MFA_CONFIG", "/nonexistent/path/secrets.yml")
 
 	_, _, err := LoadConfig()
 	if err == nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,6 +20,6 @@ func NewVersionCommand() *cobra.Command {
 }
 
 func showVersion(w io.Writer) {
-	fmt.Fprintln(w, "Version:", version)
-	fmt.Fprintln(w, "Revision:", revision)
+	_, _ = fmt.Fprintln(w, "Version:", version)
+	_, _ = fmt.Fprintln(w, "Revision:", revision)
 }


### PR DESCRIPTION
## Summary
- Add golangci-lint to CI workflow using aqua for tool management
- Fix all lint errors (errcheck, staticcheck) in the codebase

## Changes
- **CI**: Add golangci-lint step to test workflow
- **Test files**: Replace `os.MkdirTemp`/`os.RemoveAll` with `t.TempDir()` and `os.Setenv` with `t.Setenv()` for cleaner test setup
- **cmd/version.go**: Explicitly discard `fmt.Fprintln` return values
- **cmd/root.go**: Replace deprecated `SetOutput` with `SetOut`/`SetErr`

## Test plan
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)